### PR TITLE
feat: adding ecommerce status & pipeline

### DIFF
--- a/tutorretirement/patches/openedx-lms-common-settings
+++ b/tutorretirement/patches/openedx-lms-common-settings
@@ -19,6 +19,11 @@ RETIREMENT_STATES = [
     'NOTES_COMPLETE',
     {% endif %}
 
+    {% if ECOMMERCE_HOST is defined %}
+    'RETIRING_ECOMMERCE',
+    'ECOMMERCE_COMPLETE',
+    {% endif %}
+
     'RETIRING_LMS_MISC',
     'LMS_MISC_COMPLETE',
 

--- a/tutorretirement/templates/retirement/build/retirement/pipeline_config/config.yml
+++ b/tutorretirement/templates/retirement/build/retirement/pipeline_config/config.yml
@@ -4,10 +4,12 @@ client_secret: {{ RETIREMENT_EDX_OAUTH2_CLIENT_SECRET }}
 base_urls:
     lms: {{ "https" if ENABLE_HTTPS else "http" }}://{{ LMS_HOST }}
     {% if NOTES_HOST is defined %}notes: {{ "https" if ENABLE_HTTPS else "http" }}://{{ NOTES_HOST }}{% endif %}
+    {% if ECOMMERCE_HOST is defined %}ecommerce: {{ "https" if ENABLE_HTTPS else "http" }}://{{ ECOMMERCE_HOST }}{% endif %}
 
 retirement_pipeline:
     - [ 'RETIRING_ENROLLMENTS', 'ENROLLMENTS_COMPLETE', 'LMS', 'retirement_unenroll' ]
     {% if FORUM_VERSION is defined %}- [ 'RETIRING_FORUMS', 'FORUMS_COMPLETE', 'LMS', 'retirement_retire_forum' ]{% endif %}
     {% if NOTES_HOST is defined %}- [ 'RETIRING_NOTES', 'NOTES_COMPLETE', 'LMS', 'retirement_retire_notes' ]{% endif %}
+    {% if ECOMMERCE_HOST is defined %}- [ 'RETIRING_ECOMMERCE', 'ECOMMERCE_COMPLETE', 'ECOMMERCE', 'retire_learner']{% endif %}
     - [ 'RETIRING_LMS_MISC', 'LMS_MISC_COMPLETE', 'LMS', 'retirement_lms_retire_misc' ]
     - [ 'RETIRING_LMS', 'LMS_COMPLETE', 'LMS', 'retirement_lms_retire' ]


### PR DESCRIPTION
## Description
Since the ecommerce is deprecated and will be maintained in redwood, this PR was directly made to the NAU fork to add the retirement states associated with ecommerce, the ecommerce service URL, and the function that should be executed to retire ecommerce users in the pipeline

## Testing instructions
1. Build an ecommerce image with the branch worked on this [PR](https://github.com/fccn/ecommerce/pull/1)
2. Install https://github.com/fccn/tutor-contrib-retirement/pull/2 with the branch worked on that PR
3. Run a tutor local environment with ecommerce, discovery and retirement activated
4. Declare COOL_OFF_DAYS to 0 so you can test the retirement workflow without wait 30 days (or modify the retirementstatus record directly through mysql)
5. Register, go to account and delete you account
6. Run `tutor local retire-users` to check the entire retirement workflow